### PR TITLE
Fix state change for cmdGoTime state if provided value is a number

### DIFF
--- a/lib/iosbplayer.js
+++ b/lib/iosbplayer.js
@@ -747,6 +747,13 @@ function ioSBPlayer(server,playerdata) {
             }
         }
         if (idParts[0] == 'cmdGoTime') {
+            // state.val needs to be a string, although the time is set in seconds
+            // when settings cmdGoTime via ioBroker.simple-api its not possible to submit a number as string
+            // if we receive a number, we need to cast this to a string
+            if (typeof state.val === 'number') {
+                state.val = state.val.toString();
+            }
+
             if (state.val.trim()!=='' && !isNaN(state.val.trim())) {
                 this.request(this.playerid,['time', state.val.trim()]);
                 this.setState(idParts[0],' ',this.statePath,this.playername,false);


### PR DESCRIPTION
Hi oweitman, 
first of all: awesome ioBroker adapter!

**The issue**
I encountered one issue when using the ioBroker.simple-api adapter. This adapter allows to set any ioBroker state value with a HTTP API. Every squeezeboxrpc state I want to set via API works fine, except for cmdGoTime. This state is defined as "string", I assume thats because it can be set as a absolute time in seconds and a relative time like "+50" or "-50". When I set the absolute time in seconds via the HTTP API, that value is always casted to a number.

**The solution**
If the provided value is a number, we could simply cast this to a string. Then, the `state.val.trim()` will not fail with a exception (`trim()` is not available for type number). 